### PR TITLE
Added the possibility to get a clause, when using fluent query syntax

### DIFF
--- a/src/Dibi/Fluent.php
+++ b/src/Dibi/Fluent.php
@@ -225,6 +225,21 @@ class Fluent implements IDataSource
 
 
 	/**
+	 * Gets a clause
+	 * @param string clause name
+	 * @return NULL
+	 */
+	public function getClause($clause)
+	{
+		if (isset($this->clauses[self::$normalizer->$clause])) {
+			return $this->clauses[self::$normalizer->$clause];
+		}
+
+		return NULL;
+	}
+
+
+	/**
 	 * Removes a clause.
 	 * @param  string clause name
 	 * @return self


### PR DESCRIPTION
This would be useful for determining the columns to use in the GROUP BY clause